### PR TITLE
Transpile printer components in node_modules

### DIFF
--- a/packages/gatsby-plugin-printer/gen-code-bundle.js
+++ b/packages/gatsby-plugin-printer/gen-code-bundle.js
@@ -31,7 +31,6 @@ const genCodeBundle = async ({
     plugins: [
       resolve(),
       babel({
-        exclude: "**/node_modules/**",
         presets: ["babel-preset-gatsby"],
         plugins: ["babel-plugin-preval"]
       }),


### PR DESCRIPTION
This branch removes the `exclude` option from `babel()`, enabling themes to use this plugin with their own printer components. These components would be located in the node_modules directory of the theme consumer, causing `Unexpected token` errors because the files wouldn't be transpiled.