### PR TITLE
[gatsby-plugin-printer] Pin rollup to 1.23.1

### DIFF
--- a/.changeset/slow-feet-worry.md
+++ b/.changeset/slow-feet-worry.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-printer": patch
+---
+
+Pin Rollup until we figure out why new version is producing no output for ogRender

--- a/packages/gatsby-plugin-printer/package.json
+++ b/packages/gatsby-plugin-printer/package.json
@@ -13,7 +13,7 @@
     "babel-plugin-preval": "^3.0.1",
     "fs-extra": "^8.1.0",
     "puppeteer": "^1.19.0",
-    "rollup": "^1.17.0",
+    "rollup": "1.23.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-node-builtins": "^2.1.2",


### PR DESCRIPTION
I noticed that my builds were breaking after upgrading a theme that implemented `gatsby-plugin-printer`, and after much investigation, found that `rollup` was upgrading itself to v1.24.0 when I installed the new theme package, since it is considered "compatible" with the `^1.17.0` version in the printer plugin's package.json.

I was able to reproduce this error with a minimal example in this repo: https://github.com/trevorblades/printer-test

If you clone that repo, `npm install`, and then `npm run build`, you should be able to see the error "Could not find element that matches selector: ...", but downgrading `rollup` to 1.23.1 fixes the error. You can checkout the `rollup` branch in that repo and install/build again to see the build succeed again.