### PR TITLE
fix: add changeset for windows fix on gatsby-plugin-printer

### DIFF
--- a/.changeset/chilly-bees-cheer.md
+++ b/.changeset/chilly-bees-cheer.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-printer": patch
+---
+
+fix support for windows (#25) [originally in c28e64f, forgot changeset]


### PR DESCRIPTION
Forgot to add a changeset on #25. This adds it which should publish patch on merge through CI.