### PR TITLE
fix: set puppeteer back to v1

### DIFF
--- a/.changeset/lovely-pandas-marry.md
+++ b/.changeset/lovely-pandas-marry.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-printer": patch
+---
+
+set puppeteer to v1.20.0 as white screenshots on v2 and v3 currently

--- a/packages/gatsby-plugin-printer/package.json
+++ b/packages/gatsby-plugin-printer/package.json
@@ -17,7 +17,7 @@
     "@sindresorhus/slugify": "^0.9.1",
     "babel-plugin-preval": "^3.0.1",
     "fs-extra": "^8.1.0",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^1.20.0",
     "rollup": "1.23.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",


### PR DESCRIPTION
The puppeteer v2 and v3 are currently giving white screenshots. Set back to v1 until it is replaced with playwright. @ChristopherBiscardi, it seems we pushed on top of previous changes which included the update to puppeteer v2.